### PR TITLE
Fix ISM policy reconcile condition (#972)

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -89,8 +89,10 @@ To test your changes you can launch the operator locally. You need a running kub
 
 By default the operator produces logs in a JSON format. For easier reading during debugging you can switch the logging framework into a special development mode that switches off JSON and produces more details (stacktraces on warnings). Simply set the environment variable `OPERATOR_DEV_LOGGING=true` before running. E.g. to run locally with make: `OPERATOR_DEV_LOGGING=true make run`. If you want to enable this mode for a deployed operator use the `manager.extraEnv` helm chart values option to set the environment variable.
 
-Note that for some features the operator expects to be able to communicate directly with opensearch. This is not possible when the operator is running outside of kubernetes. In these cases you will need to deploy the operator to test it. Follow these steps:
-
+Note that for some features the operator expects to be able to communicate directly with opensearch. This could be achieved in 2 ways:
+1) Add Opensearch cluster DNS to your hosts file, e.g. `/etc/hosts`. Point it to localhost address.
+   E.g. `127.0.0.1 opensearch-primary.opensearch.svc.cluster.local`. Then port-forward `9200` and `9300` ports from kubernetes to your local env.
+2) Deploy the operator to remote cluster to test it. Follow these steps:
 * Run `make docker-build` to build the docker image
 * If needed import the image into your cluster (for k3d run `k3d image import controller:latest`)
 * Deploy the operator with helm by running `helm install opensearch-operator ../charts/opensearch-operator --set manager.image.repository=controller --set manager.image.tag=latest --set manager.image.pullPolicy=IfNotPresent`

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -163,7 +163,7 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 		}, retErr
 	}
 
-	// If PolicyID is not provided explicitly, use metadata.name by default
+	// If PolicyId is not provided explicitly, use metadata.name by default
 	policyId = r.instance.Name
 	if r.instance.Spec.PolicyID != "" {
 		policyId = r.instance.Spec.PolicyID
@@ -251,8 +251,8 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 	}
 
 	// Return if there are no changes
-	if r.instance.Spec.PolicyID == existingPolicy.PolicyID && cmp.Equal(*newPolicy, existingPolicy.Policy, cmpopts.EquateEmpty()) {
-		r.logger.V(1).Info(fmt.Sprintf("user %s is in sync", r.instance.Name))
+	if r.instance.Status.PolicyId == existingPolicy.PolicyID && cmp.Equal(*newPolicy, existingPolicy.Policy, cmpopts.EquateEmpty()) {
+		r.logger.V(1).Info(fmt.Sprintf("policy %s is in sync", r.instance.Name))
 		r.recorder.Event(r.instance, "Normal", opensearchAPIUnchanged, "policy is in sync")
 		return ctrl.Result{
 			Requeue:      true,
@@ -579,7 +579,7 @@ func (r *IsmPolicyReconciler) Delete() error {
 		return err
 	}
 
-	// If PolicyID not provided explicitly, use metadata.name by default
+	// If PolicyId not provided explicitly, use metadata.name by default
 	policyId := r.instance.Spec.PolicyID
 	if policyId == "" {
 		policyId = r.instance.Name

--- a/opensearch-operator/pkg/reconcilers/ismpolicy_test.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy_test.go
@@ -38,7 +38,6 @@ var _ = Describe("ism policy reconciler", func() {
 		transport = httpmock.NewMockTransport()
 		transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
 		instance = &opsterv1.OpenSearchISMPolicy{
-
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-policy",
 				Namespace: "test-policy",
@@ -49,6 +48,9 @@ var _ = Describe("ism policy reconciler", func() {
 				OpensearchRef: corev1.LocalObjectReference{
 					Name: "test-cluster",
 				},
+			},
+			Status: opsterv1.OpensearchISMPolicyStatus{
+				PolicyId: "test-policy",
 			},
 		}
 
@@ -260,6 +262,7 @@ var _ = Describe("ism policy reconciler", func() {
 		Context("policy exists in opensearch", func() {
 			BeforeEach(func() {
 				instance.Spec.PolicyID = "test-policy-id"
+				instance.Status.PolicyId = "test-policy-id"
 
 				transport.RegisterResponder(
 					http.MethodGet,


### PR DESCRIPTION
### Description
Operator was constantly reconciling ISM Policy, because `PolicyId` is coming from `Status.PolicyId` and not from `Spec.PolicyID` field.


![ism-bug](https://github.com/user-attachments/assets/b2c40248-8280-4571-9f67-c5eff661c0b5)


Also, updated developing documentation with instructions on how to run the operator locally and connect to the remote Opensearch cluster. It helped me a lot during debugging, so I hope it will be useful to someone else.

### Issues Resolved
Closes #833

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [x] Changes to CRDs documented

Please refer to the [PR
guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check
[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

---------

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
